### PR TITLE
Add user_name and team_name to identity

### DIFF
--- a/app/models/slack_sign_in/identity.rb
+++ b/app/models/slack_sign_in/identity.rb
@@ -19,6 +19,14 @@ class SlackSignIn::Identity
     params.dig("user", "name")
   end
 
+  def user_name
+    params.dig("user", "name")
+  end
+
+  def team_name
+    params.dig("team", "name")
+  end
+
   def email
     params.dig("user", "email")
   end


### PR DESCRIPTION
`user_name` is kinda duplicate, but to keep backwards compatibility I left original `name`.

`team_name` is important, cos we have it - why hiding?

Maybe it's worth changing `params` privacy to public in the future. There are useful.