### PR TITLE
Update authorize & token urls with OAuth 2.0

### DIFF
--- a/lib/slack_sign_in.rb
+++ b/lib/slack_sign_in.rb
@@ -3,8 +3,8 @@ require "slack_sign_in/engine"
 module SlackSignIn
   DEFAULT_SCOPES = %w[identity.basic identity.email identity.avatar]
 
-  AUTHORIZE_URL = "https://slack.com/oauth/authorize"
-  TOKEN_URL = "https://slack.com/api/oauth.access"
+  AUTHORIZE_URL = "https://slack.com/oauth/v2/authorize"
+  TOKEN_URL = "https://slack.com/api/oauth.v2.access"
 
   mattr_accessor :client_id, :client_secret
   mattr_accessor :scopes, :client


### PR DESCRIPTION
Updated a legacy method `AUTHORIZE_URL` and `TOKEN_URL` with `oauth.v2.access`